### PR TITLE
Add adam example, fails with docker.runOptions

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -7,6 +7,10 @@ workflow {
 
     main:
         PRINT_ENV().view()
+
+        data = Channel.fromPath("test/**.sam").map { path -> tuple(path.baseName, path) }
+        ADAM_TRANSFORMALIGNMENTS(data)
+        ADAM_TRANSFORMALIGNMENTS.out.bam.view()
 }
 
 process PRINT_ENV {
@@ -20,4 +24,20 @@ process PRINT_ENV {
     echo "-u \$(id -u):\$(id -g)"
     """
 
+}
+
+process ADAM_TRANSFORMALIGNMENTS {
+    tag "${sample}"
+    container "quay.io/biocontainers/adam:0.35.0--hdfd78af_0"
+
+    input:
+    tuple val(sample), path(sam)
+
+    output:
+    tuple val(sample), path("*.bam"), emit: bam
+
+    script:
+    """
+    adam-submit transformAlignments -single ${sam} ${sample}.bam
+    """
 }


### PR DESCRIPTION
Running locally with the docker profile and `docker.runOptions = '-u \$(id -u):\$(id -g)'`, this example fails due to the Ivy cache
```
$ nextflow run main.nf -profile docker
N E X T F L O W  ~  version 20.10.0
Launching `main.nf` [astonishing_becquerel] - revision: 61e54fbb76
executor >  local (2)
[94/79f414] process > PRINT_ENV                        [  0%] 0 of 1
[bf/c301a1] process > ADAM_TRANSFORMALIGNMENTS (empty) [  0%] 0 of 1
Error executing process > 'ADAM_TRANSFORMALIGNMENTS (empty)'

Caused by:
  Process `ADAM_TRANSFORMALIGNMENTS (empty)` terminated with an error exit status (1)

Command executed:

  adam-submit transformAlignments -single empty.sam empty.bam

executor >  local (2)
[-        ] process > PRINT_ENV                        -
[bf/c301a1] process > ADAM_TRANSFORMALIGNMENTS (empty) [100%] 1 of 1, failed: 1 ✘
Error executing process > 'ADAM_TRANSFORMALIGNMENTS (empty)'

Caused by:
  Process `ADAM_TRANSFORMALIGNMENTS (empty)` terminated with an error exit status (1)

Command executed:

  adam-submit transformAlignments -single empty.sam empty.bam

Command exit status:
  1

Command output:
  (empty)

Command error:
  Using ADAM_MAIN=org.bdgenomics.adam.cli.ADAMMain
  Using spark-submit=/usr/local/bin/spark-submit
  WARNING: An illegal reflective access operation has occurred
  WARNING: Illegal reflective access by org.apache.spark.unsafe.Platform (file:/usr/local/lib/python3.9/site-packages/pyspark/jars/spark-unsafe_2.12-3.1.1.jar) to constructor java.nio.DirectByteBuffer(long,int)
  WARNING: Please consider reporting this to the maintainers of org.apache.spark.unsafe.Platform
  WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
  WARNING: All illegal access operations will be denied in a future release
  Exception in thread "main" java.lang.IllegalArgumentException: basedir must be absolute: ?/.ivy2/local
  	at org.apache.ivy.util.Checks.checkAbsolute(Checks.java:48)
  	at org.apache.ivy.plugins.repository.file.FileRepository.setBaseDir(FileRepository.java:135)
  	at org.apache.ivy.plugins.repository.file.FileRepository.<init>(FileRepository.java:44)
  rk dirat org.apache.spark.deploy.SparkSubmitUtils$.createRepoResolvers(SparkSubmit.scala:1166)
  /Usersat org.apache.spark.deploy.SparkSubmitUtils$.buildIvySettings(SparkSubmit.scala:1261)
  	at org.apache.spark.deploy.DependencyUtils$.resolveMavenDependencies(DependencyUtils.scala:51)
  p: vieat org.apache.spark.deploy.SparkSubmit.prepareSubmitEnvironment(SparkSubmit.scala:308)
  RN: Kiat org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:894)
  	at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:180)
  	at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:203)
  	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:90)
  	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1030)
  	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1039)
  	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)

Work dir:
  working/nextflow-docker-actions-test/work/bf/c301a1ba43515ebc261db5c493b88a

Tip: view the complete command output by changing to the process work dir and entering the command `cat .command.out`
```

whereas it runs ok without `runOptions` set
```
$ nextflow run main.nf -profile docker
N E X T F L O W  ~  version 20.10.0
Launching `main.nf` [berserk_church] - revision: 61e54fbb76
executor >  local (2)
[2a/c5026b] process > PRINT_ENV                        [100%] 1 of 1 ✔
[0e/da5a00] process > ADAM_TRANSFORMALIGNMENTS (empty) [100%] 1 of 1 ✔
HOSTNAME=6ffef5d176ba
PWD=/Users/heuermh/working/nextflow-docker-actions-test/work/2a/c5026b7f01578898a72269a03b3420
_=/usr/bin/env
HOME=/root
SHLVL=1
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-u 0:0

[empty, working/nextflow-docker-actions-test/work/0e/da5a00962c3d5e60dbbaa3b7114bbb/empty.bam]
```

The [work in progress nf-core module](https://github.com/nf-core/modules/pull/308) has some extra fiddling in it to workaround the Ivy cache issue
```nextflow

    """
    mkdir .spark-local
    TMP=`realpath .spark-local`

    export SPARK_LOCAL_IP=127.0.0.1
    export SPARK_PUBLIC_DNS=127.0.0.1
    adam-submit \\
        --master local[${task.cpus}] \\
        --driver-memory ${task.memory.toGiga()}g \\
        --conf spark.local.dir=\$TMP \\
        --conf spark.jars.ivy=\$TMP/.ivy2 \\
        -- \\
        transformAlignments \\
        ...
```

The `SPARK_LOCAL_IP`/`SPARK_PUBLIC_DNS` stuff was required to get Singularity to work, if I remember correctly.